### PR TITLE
TOOLS 1543 & 1535 add zabbix support up to 5.1

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ Features
   - `$ asinfo -v 'namespace/<NAMESPACE_NAME>' [-h host]`
   - `$ asinfo -v 'dc/<DC_NAME>' [-h host]` pre 5.0
   - `$ asinfo -v 'get-stats:context=xdr;dc=<DC_NAME>' [-h host]` 5.0+
-  - `$ asinfo -v 'latency:' [-h host]` pre 5.0
+  - `$ asinfo -v 'latency:' [-h host]` pre 5.1
   - `$ asinfo -v 'latencies:' [-h host]` 5.1+
   - `$ asinfo -v 'sets/<NAMESPACE_NAME>/<SET_NAME>' [-h host]`
   - `$ asinfo -v 'sindex/<NAMESPACE_NAME>/<SINDEX_NAME>' [-h host]`
@@ -80,7 +80,7 @@ you are not required to interact with it.
 
 The default template has 5 example triggers: free memory/disk, stop_writes, cluster_size, dc_state (pre 5.0)
 and latency_ms (5.0+). The free memory/disk trigger uses a template macro `{$ASD_FREE_PCT_LIMIT}` to determine 
-when the to trigger while the others use static values. Each trigger should be modified to fit your particular 
+when to trigger while the others use static values. Each trigger should be modified to fit your particular 
 aerospike configuration.
 
 To add more alerts via the LLD discovery mechanism, you will need to define a new Discovery Rule. This

--- a/Readme.md
+++ b/Readme.md
@@ -97,6 +97,7 @@ You can still define individual alert triggers outside of the LLD mechanism.
 
 ###  Usage
 ```bash
+./aerospike_discovery.py --help
 usage: aerospike_discovery.py [-u] [-U USER] [-P [PASSWORD]]
                               [--credentials-file CREDENTIALS]
                               [--auth-mode AUTH_MODE] [-v]
@@ -148,7 +149,7 @@ optional arguments:
   --tls-keyfile TLS_KEYFILE
                         The private keyfile for your client TLS Cert
   --tls-keyfile-pw TLS_KEYFILE_PW
-                        Password to load protected tls_keyfile
+                        Password to load protected tls-keyfile
   --tls-certfile TLS_CERTFILE
                         The client TLS cert
   --tls-cafile TLS_CAFILE
@@ -168,9 +169,10 @@ optional arguments:
                         Blacklist including serial number of certs to revoke
   --tls-crl-check       Checks SSL/TLS certs against vendor's Certificate
                         Revocation Lists for revoked certificates. CRLs are
-                        found in path specified by --tls_capath. Checks the
+                        found in path specified by --tls-capath. Checks the
                         leaf certificates only
   --tls-crl-check-all   Check on all entries within the CRL chain
+
 
 ```
 The `dummy` variable is just there so Alert Triggers can be set in batches based on item prototypes. 

--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,8 @@ Features
   - `$ asinfo -v 'namespace/<NAMESPACE_NAME>' [-h host]`
   - `$ asinfo -v 'dc/<DC_NAME>' [-h host]` pre 5.0
   - `$ asinfo -v 'get-stats:context=xdr;dc=<DC_NAME>' [-h host]` 5.0+
-  - `$ asinfo -v 'latency:' [-h host]`
+  - `$ asinfo -v 'latency:' [-h host]` pre 5.0
+  - `$ asinfo -v 'latencies:' [-h host]` 5.1+
   - `$ asinfo -v 'sets/<NAMESPACE_NAME>/<SET_NAME>' [-h host]`
   - `$ asinfo -v 'sindex/<NAMESPACE_NAME>/<SINDEX_NAME>' [-h host]`
   - `$ asinfo -v 'bins/<NAMESPACE_NAME>' [-h host]`
@@ -194,7 +195,7 @@ aerospike_discovery.py -h YOUR_ASD_HOST -l
 
 To monitor a specific latency metric:
 ```
-aerospike_discovery.py -h YOUR_ASD_HOST -l -s YOUR_HISTOGRAM-[tps|1ms|2ms|4ms|8ms]
+aerospike_discovery.py -h YOUR_ASD_HOST -l -s YOUR_HISTOGRAM
 ```
   - For instance, to monitor latencies greater than 8ms for histogram {test}-write:
   ```

--- a/Readme.md
+++ b/Readme.md
@@ -7,24 +7,33 @@ The goal is to reduce the complexity to 3 simple steps.
 2. Import the configuration template into Zabbix.
 3. Add the new Aerospike Serivce Template to Aerospike Hosts in Zabbix.
 
-This project is currently in beta. Any suggestions or improvements are welcome through
+Any suggestions or improvements are welcome through
 Git comments/issues and/or pull requests.
 
 Features
 ---
 
-- Can monitor any stat returned by
+- Can monitor any metric returned by
   - `$ asinfo -v 'statistics' [-h <HOST>]`
-  - `$ asinfo -v 'namespace/<NAMESPACE NAME>' [-h host]`
-  - `$ asinfo -v 'dc/<DATACENTER NAME>' [-h host]`
+  - `$ asinfo -v 'namespace/<NAMESPACE_NAME>' [-h host]`
+  - `$ asinfo -v 'dc/<DC_NAME>' [-h host]` pre 5.0
+  - `$ asinfo -v 'get-stats:context=xdr;dc=<DC_NAME>' [-h host]` 5.0+
+  - `$ asinfo -v 'latency:' [-h host]`
+  - `$ asinfo -v 'sets/<NAMESPACE_NAME>/<SET_NAME>' [-h host]`
+  - `$ asinfo -v 'sindex/<NAMESPACE_NAME>/<SINDEX_NAME>' [-h host]`
+  - `$ asinfo -v 'bins/<NAMESPACE_NAME>' [-h host]`
 
 ### Known Issues
 
-- Not all non-numeric metrics have been converted to numeric
+- Metrics that return values other than numerics, `true/false`, `on/off` are not handled
+with the exception of dc_state (pre 5.0).  All values returned are numeric. 
+- The example template shows some errors in the zabbix UI caused by returned configuration 
+paramaters which are not converted to numeric.
 - SELinux (CentOS) interferes with simple net checks built into Zabbix.
   * Get around this by setting SELinux to disabled or permissive in `/etc/selinux.config`
 
 ### Requirements
+
 Additional python modules are required and installed using pip:
 ```
 sudo pip install -r requirements.txt
@@ -36,13 +45,13 @@ See requirements.txt.
 
 Many popular distributions have Zabbix packages provided. You can follow along with their [official install documentation](https://www.zabbix.com/documentation/4.4/manual/installation/install_from_packages) or use a third party guide like the one [written by Digital Ocean](https://www.digitalocean.com/community/tutorials/how-to-install-zabbix-on-ubuntu-configure-it-to-monitor-multiple-vps-servers).
 
-Note: Zabbix 4.4 needed. Older versions may not be able to import aerospike template.
+Note: Zabbix 4.4+ needed. Older versions may not be able to import aerospike template.
 
 
 ### Getting Started
 
 1. Enable [external scripts](https://www.zabbix.com/documentation/4.4/manual/config/items/itemtypes/external)
-for Zabbix Server. You may have already done this for other Zabbix plugins 
+for Zabbix Server. You may have already done this for other Zabbix plugins. Default: /usr/lib/zabbix/externalscripts
 2. Copy aerospike\_discovery.py to the external scripts directory and make it executable
   * ie: chmod +x aerospike\_discovery.py
 3. Copy ssl folder to same external scripts directory.
@@ -50,11 +59,13 @@ for Zabbix Server. You may have already done this for other Zabbix plugins
 5. In Configuration -> Templates section of Zabbix, click `Import` and choose aerospike\_templates.xml.
 6. Add the newly imported `Template App Aerospike Service` to your Aerospike Hosts.
 
-### Namespace Checks
+### Default Checks
 
-The default template contains namespace checks for the namespace `test`. To change
-this to another namespace, go to Configuration -> Templates, and click on the Discovery section of
-Template App Aerospike Service. Click on Aerospike Test Namespace Metric, and change `test` to the name of your namespace. For example, if your namespace was `fizzbuzz`:
+The default template contains checks for testing and requires modification to monitor your aerospike configuration. 
+To modify the default template goto Configuration -> Templates, and click on the Discovery section of
+Template App Aerospike Service. Click on any of the Discovery Rules and change the key so that the arguments to
+`aerospike_discovery.py` match your current namespaces, sets, datacenters, etc.  For instance to monitor all metrics
+for the namespace `fizzbuzz` change the Aerospike Namespace discovery rule key to:
 
     aerospike_discovery[-h,{HOST.IP},-n,fizzbuzz]
 
@@ -66,13 +77,18 @@ you are not required to interact with it.
 
 ### Alert Triggers
 
-The main alert trigger is free memory/disk and if the namespace is in stop_writes. The free memory/disk 
-trigger is set as a template macro `{$ASD_FREE_PCT_LIMIT}`.
+The default template has 5 example triggers: free memory/disk, stop_writes, cluster_size, dc_state (pre 5.0)
+and latency_ms (5.0+). The free memory/disk trigger uses a template macro `{$ASD_FREE_PCT_LIMIT}` to determine 
+when the to trigger while the others use static values. Each trigger should be modified to fit your particular 
+aerospike configuration.
 
-To add more alerts via the LLD discovery mechanism, you will need to define a new Item prototype. This
-item protoytype will need to duplicate the existing discovery key, with the added exception of a unique 
-dummy variable. This is used since the same key cannot be used for multiple item prototype. You will also
-need to add a macro filter to this item prototype to filter down the results to your interested metrics.
+To add more alerts via the LLD discovery mechanism, you will need to define a new Discovery Rule. This
+discovery rule will need to duplicate the existing discovery key, with the added exception of a unique 
+dummy variable. This is used since the same key cannot be used for multiple discovery rules or item prototype. You will also
+need to add a macro filter to this discovery rule to filter down the results to your interested metrics.
+
+Next create a new item prototype which is a duplicate of the existing item prototype, with the added exception
+of a different key.  You can change the name as well if your prefer.
 
 Next you will need to create a new trigger prototype using the item prototype that was just created.
 
@@ -81,14 +97,17 @@ You can still define individual alert triggers outside of the LLD mechanism.
 ###  Usage
 ```bash
 usage: aerospike_discovery.py [-u] [-U USER] [-P [PASSWORD]]
+                              [--credentials-file CREDENTIALS]
                               [--auth-mode AUTH_MODE] [-v]
-                              [-n NAMESPACE | -l LATENCY | -x DC] [-s STAT]
-                              [-p PORT] [-h HOST] [-d DUMMY]
-                              [--timeout TIMEOUT] [--tls-enable]
-                              [--tls-name TLS_NAME] [--tls-keyfile TLS_KEYFILE]
+                              [-n NAMESPACE | -l | -x DC]
+                              [-t SET | -b | -i SINDEX] [-s STAT] [-p PORT]
+                              [-h HOST] [-d DUMMY] [--timeout TIMEOUT]
+                              [--tls-enable] [--tls-name TLS_NAME]
+                              [--tls-keyfile TLS_KEYFILE]
                               [--tls-keyfile-pw TLS_KEYFILE_PW]
                               [--tls-certfile TLS_CERTFILE]
-                              [--tls-cafile TLS_CAFILE] [--tls-capath TLS_CAPATH]
+                              [--tls-cafile TLS_CAFILE]
+                              [--tls-capath TLS_CAPATH]
                               [--tls-ciphers TLS_CIPHERS]
                               [--tls-protocols TLS_PROTOCOLS]
                               [--tls-cert-blacklist TLS_CERT_BLACKLIST]
@@ -99,15 +118,23 @@ optional arguments:
   -U USER, --user USER  user name
   -P [PASSWORD], --password [PASSWORD]
                         password
+  --credentials-file CREDENTIALS
+                        Path to the credentials file. Use this in place of
+                        --user and --password.
   --auth-mode AUTH_MODE
                         Authentication mode. Values: ['EXTERNAL_INSECURE',
                         'INTERNAL', 'EXTERNAL'] (default: INTERNAL)
   -v, --verbose         Enable verbose logging
   -n NAMESPACE, --namespace NAMESPACE
                         Namespace name. eg: bar
-  -l LATENCY, --latency LATENCY
-                        Options: see output of asinfo -v 'latency:hist' -l
+  -l, --latency         Options: see output of asinfo -v 'latency:hist' -l
   -x DC, --xdr DC       Datacenter name. eg: myDC1
+  -t SET, --set SET     Set name. eg: testSet. Statistic for a particular set
+                        in a particular namespace.
+  -b, --bin             Bin usage information for a particular namspace.
+  -i SINDEX, --sindex SINDEX
+                        Secondary Index name. eg: age. Statistic for a
+                        particular secondary index in a particular namespace.
   -s STAT, --stat STAT  Statistic name. eg: cluster_size
   -p PORT, ---port PORT
                         PORT for Aerospike server (default: 3000)
@@ -120,7 +147,7 @@ optional arguments:
   --tls-keyfile TLS_KEYFILE
                         The private keyfile for your client TLS Cert
   --tls-keyfile-pw TLS_KEYFILE_PW
-                        Password to load protected --tls-keyfile
+                        Password to load protected tls_keyfile
   --tls-certfile TLS_CERTFILE
                         The client TLS cert
   --tls-cafile TLS_CAFILE
@@ -129,8 +156,8 @@ optional arguments:
                         The path to a directory containing CA certs and/or
                         CRLs
   --tls-ciphers TLS_CIPHERS
-                        Ciphers to include. See See https://www.openssl.org/docs/m
-                        an1.1.0/man1/ciphers.html for cipher list format
+                        Ciphers to include. See https://www.openssl.org/docs/m
+                        an1.0.1/apps/ciphers.html for cipher list format
   --tls-protocols TLS_PROTOCOLS
                         The TLS protocol to use. Available choices: TLSv1,
                         TLSv1.1, TLSv1.2, all. An optional + or - can be
@@ -140,7 +167,7 @@ optional arguments:
                         Blacklist including serial number of certs to revoke
   --tls-crl-check       Checks SSL/TLS certs against vendor's Certificate
                         Revocation Lists for revoked certificates. CRLs are
-                        found in path specified by --tls-capath. Checks the
+                        found in path specified by --tls_capath. Checks the
                         leaf certificates only
   --tls-crl-check-all   Check on all entries within the CRL chain
 
@@ -150,28 +177,87 @@ However the item prototype needs to have unique keys (read: unique external scri
 dummy variable is there to satisfy this uniqueness.
 
 ### Examples
-To monitor all general statistics:
+To monitor all general metrics:
 ```
 aerospike_discovery.py -h YOUR_ASD_HOST
 ```
 
-To monitor all statistics in a namespace:
+To monitor a specific general metric:
+```
+aerospike_discovery.py -h YOUR_ASD_HOST -s YOUR_METRIC_NAME 
+```
+
+To monitor all latency metrics:
+```
+aerospike_discovery.py -h YOUR_ASD_HOST -l
+```
+
+To monitor a specific latency metric:
+```
+aerospike_discovery.py -h YOUR_ASD_HOST -l -s YOUR_HISTOGRAM-[tps|1ms|2ms|4ms|8ms]
+```
+  - For instance, to monitor latencies greater than 8ms for histogram {test}-write:
+  ```
+  aerospike_discovery.py -h 127.0.0.1 -l -s {test}-write-8ms
+  ```
+
+To monitor all metrics in a namespace:
 ```
 aerospike_discovery.py -h YOUR_ASD_HOST -n YOUR_NAMESPACE
 ```
 
-To monitor a specific general statistic:
+To monitor a specific metric in a namespace:
 ```
-aerospike_discovery.py -h YOUR_ASD_HOST -s SERVICE_NAME
-```
-
-To monitor a specific statistic in a namespace:
-```
-aerospike_discovery.py -h YOUR_ASD_HOST -s SERVICE_NAME -n YOUR_NAMESPACE
+aerospike_discovery.py -h YOUR_ASD_HOST -n YOUR_NAMESPACE -s YOUR_METRIC_NAME 
 ```
 
-To monitor all XDR statistics for a datacenter:
+To monitor all metrics in a set:
 ```
-aerospike_discovery.py -h YOUR_ASD_HOST -x DATACENTER
+aerospike_discovery.py -h YOUR_ASD_HOST -n YOUR_NAMESPACE -t YOUR_SET_NAME
 ```
 
+To monitor a specific metric in a set:
+```
+aerospike_discovery.py -h YOUR_ASD_HOST -n YOUR_NAMESPACE -t YOUR_SET_NAME -s YOUR_METRIC_NAME
+```
+
+To monitor all bin metrics in a namespace:
+```
+aerospike_discovery.py -h YOUR_ASD_HOST -n YOUR_NAMESPACE -b
+```
+
+To monitor a specific bin metrics in a namespace:
+```
+aerospike_discovery.py -h YOUR_ASD_HOST -n YOUR_NAMESPACE -b -s YOUR_METRIC_NAME
+```
+
+To monitor all sIndex metrics for a sIndex in a namespace:
+```
+aerospike_discovery.py -h YOUR_ASD_HOST -n YOUR_NAMESPACE -i YOUR_SINDEX
+```
+
+To monitor a specific sIndex metric for a sIndex in a namespace:
+```
+aerospike_discovery.py -h YOUR_ASD_HOST -n YOUR_NAMESPACE -i YOUR_SINDEX -s YOUR_METRIC_NAME
+```
+
+To monitor all XDR metrics for a datacenter:
+```
+aerospike_discovery.py -h YOUR_ASD_HOST -x YOUR_DATACENTER
+```
+
+To monitor a specific XDR metric for a datacenter:
+```
+aerospike_discovery.py -h YOUR_ASD_HOST -x YOUR_DATACENTER -s METRIC_NAME 
+```
+
+### Authentication
+
+You can specify User and Password for authentication via the -U/--user and -P/--password parameters.
+The Password is also an interactive prompt if you leave it empty.
+                        
+If this is not preferable, you can also specify a credentials file with -c/--credentials-file. 
+It is a simple 2 line file, with the username and password on each line, in that order. 
+With this method, the credentials file can be secured via other means (eg: chmod 600) and prevent snooping.
+
+`AuthMode` is optional parameter to specify authentication mode. It's default value is INTERNAL.

--- a/aerospike_discovery.py
+++ b/aerospike_discovery.py
@@ -594,30 +594,30 @@ latency_histogram = ''
 latency_time = ''
 
 if args.dc:
-        asinfo_cmd='dc/'+args.dc
+        asinfo_cmd = 'dc/' + args.dc
 
         # Version 5.0+ got removed dc/DC_NAME and added get-stats:context=xdr;dc=DC_NAME
         if int(version[0]) >= 5:
-            asinfo_cmd='get-stats:context=xdr;dc='+args.dc
+            asinfo_cmd = 'get-stats:context=xdr;dc=' + args.dc
 
 # namespace must be checked after sets, bins, and sindex
 elif args.set:
-    asinfo_cmd='sets/'+args.namespace+'/'+args.set
+    asinfo_cmd = 'sets/' + args.namespace + '/' + args.set
 elif args.bin:
-    asinfo_cmd='bins/'+args.namespace
+    asinfo_cmd = 'bins/' + args.namespace
 elif args.sindex:
-    asinfo_cmd='sindex/'+args.namespace+'/'+args.sindex
+    asinfo_cmd = 'sindex/' + args.namespace + '/' + args.sindex
 elif args.namespace:
-    asinfo_cmd='namespace/'+args.namespace
+    asinfo_cmd = 'namespace/' + args.namespace
 elif args.latency:
     if use_latencies_cmd:
-        asinfo_cmd='latencies:'
+        asinfo_cmd = 'latencies:'
     else:
-        asinfo_cmd='latency:'
+        asinfo_cmd = 'latency:'
     if args.stat:
         latency_histogram, latency_time = args.stat.rsplit('-', 1)
         print(latency_histogram, latency_time)
-        asinfo_cmd+="hist="+latency_histogram
+        asinfo_cmd += "hist=" + latency_histogram
 
 try:
     res = client.info(asinfo_cmd).strip()

--- a/aerospike_discovery.py
+++ b/aerospike_discovery.py
@@ -589,7 +589,7 @@ except Exception as e:
         print(e)
         sys.exit(STATE_UNKNOWN)
 
-use_latencies_cmd = int(version[0]) >= 5 and int(version[1]) >= 1
+use_latencies_cmd = int(version[0]) > 5 or (int(version[0]) == 5 and int(version[1]) >= 1)
 latency_histogram = ''
 latency_time = ''
 

--- a/aerospike_discovery.py
+++ b/aerospike_discovery.py
@@ -589,7 +589,7 @@ except Exception as e:
         print(e)
         sys.exit(STATE_UNKNOWN)
 
-use_latencies_cmd = True if int(version[0]) >= 5 and int(version[1]) >= 1 else False
+use_latencies_cmd = int(version[0]) >= 5 and int(version[1]) >= 1
 latency_histogram = ''
 latency_time = ''
 
@@ -666,7 +666,6 @@ res = res.strip()
 # Output stream collects output to send to stdout and looks up metrics
 stream = OutputStream()
 
-# first = True
 metric_found = False
 if args.latency:
     res = res.split(';')

--- a/aerospike_discovery.py
+++ b/aerospike_discovery.py
@@ -365,17 +365,21 @@ class OutputStream():
         metricunits = ''
         if "pct" in metricname:
             metricunits = '%'
-        elif "bytes" in metricname:
-            metricunits = 'B'
+        # All Byte metrics have "bytes" in the name except the values in this set.
+        elif "bytes" in metricname or metricname in {"ibtr_memory_used", "nbtr_memory_used", "si_accounted_memory"}:
+            metricunits = 'Bytes'
 
         # Convert non numeric values to numeric
         if metricvalue == "true" or metricvalue == "on":
             metricvalue = "1"
+            metricunits = "Bool"
         elif metricvalue == "false" or metricvalue == "off":
             metricvalue = "0"
+            metricunits = "Bool"
 
         if metricname in {"cluster_key", "cluster_principal", "paxos_principal"}:
             metricvalue = str(int(metricvalue,16)) # Convert HEX id to numerical
+        # dc_state is a metric in pre 5.0 server
         elif metricname == "dc_state":
             if metricvalue == "CLUSTER_INACTIVE":
                 metricvalue = "0"

--- a/aerospike_discovery.py
+++ b/aerospike_discovery.py
@@ -160,7 +160,7 @@ class Client(object):
             except Exception as msg:
                 s.close()
                 s = None
-                print "Connect Error %s" % msg
+                print ("Connect Error %s" % msg)
                 continue
 
             break
@@ -477,7 +477,7 @@ try:
                    tls_crl_check=args.tls_crl_check, tls_crl_check_all=args.tls_crl_check_all,)
 except Exception as e:
     print("Failed to connect to the Aerospike cluster at %s:%s"%(args.host,args.port))
-    print e
+    print(e)
     sys.exit(STATE_UNKNOWN)
 
 if user:
@@ -488,32 +488,32 @@ if user:
             sys.exit(STATE_UNKNOWN)
     except Exception as e:
         print("Failed to authenticate connection to the Aerospike cluster at %s:%s"%(args.host,args.port))
-        print e
+        print(e)
         sys.exit(STATE_UNKNOWN)
 
 try:
     r = client.info(arg_value).strip()
 except Exception as e:
     print("Failed to execute asinfo command %s on the Aerospike cluster at %s:%s"%(arg_value, args.host, args.port))
-    print e
+    print(e)
     sys.exit(STATE_UNKNOWN)
 
 client.close()
 
 if r == None:
-    print "request to ",args.host,":",args.port," returned no data."
+    print("request to ",args.host,":",args.port," returned no data.")
     sys.exit(STATE_CRITICAL)
 
 if r == -1:
-    print "request to ",args.host,":",args.port," returned error."
+    print("request to ",args.host,":",args.port," returned error.")
     sys.exit(STATE_CRITICAL)
 
 if args.stat != None and args.stat not in r:
-    print "%s is not a known statistic." %args.stat
+    print("%s is not a known statistic." %args.stat)
     sys.exit(STATE_UNKNOWN)
 
-print "{"
-print "\t\"data\":["
+print("{")
+print("\t\"data\":[")
 first = True
 r = r.strip()
 for s in r.split(";"):
@@ -523,7 +523,7 @@ for s in r.split(";"):
         if args.stat != metricname:
             continue
     if not first:
-        print "\t,"
+        print("\t,")
     first = False
     if metricvalue == "true" or metricvalue == "on":
         metricvalue = "1"
@@ -531,11 +531,11 @@ for s in r.split(";"):
         metricvalue = "0"
     if metricname == "cluster_key":
         metricvalue = str(int(metricvalue,16)) # Convert HEX id to numerical
-    print "\t{"
-    print "\t\t\"{#METRICNAME}\":\""+metricname+"\","
-    print "\t\t\"{#METRICVALUE}\":\""+metricvalue+"\""
-    print "\t}"
+    print("\t{")
+    print("\t\t\"{#METRICNAME}\":\""+metricname+"\",")
+    print("\t\t\"{#METRICVALUE}\":\""+metricvalue+"\"")
+    print("\t}")
 
-print "\t]"
-print "}"
+print("\t]")
+print("}")
 sys.exit(STATE_OK)

--- a/aerospike_discovery.py
+++ b/aerospike_discovery.py
@@ -184,7 +184,7 @@ class Client(object):
             send_buf = self._admin_write_header(sz, _LOGIN, 2)
             fmt_str = "! I B %ds I B %ds" % (len(user), len(credential))
             struct.pack_into(fmt_str, send_buf, _HEADER_SIZE,
-                             len(user) + 1, _USER_FIELD_ID, user,
+                             len(user) + 1, _USER_FIELD_ID, user.encode(),
                              len(credential) + 1, _CREDENTIAL_FIELD_ID, credential)
 
         else:
@@ -192,14 +192,14 @@ class Client(object):
             send_buf = self._admin_write_header(sz, _LOGIN, 3)
             fmt_str = "! I B %ds I B %ds I B %ds" % (len(user), len(credential), len(password))
             struct.pack_into(fmt_str, send_buf, _HEADER_SIZE,
-                             len(user) + 1, _USER_FIELD_ID, user,
+                             len(user) + 1, _USER_FIELD_ID, user.encode(),
                              len(credential) + 1, _CREDENTIAL_FIELD_ID, credential,
-                             len(password) + 1, _CLEAR_PASSWORD_FIELD_ID, password)
+                             len(password) + 1, _CLEAR_PASSWORD_FIELD_ID, password.encode())
 
         try:
             # OpenSSL wrapper doesn't support ctypes
             send_buf = self._buffer_to_string(send_buf)
-            self.sock.sendall(send_buf)
+            self.sock.sendall(send_buf.encode())
             recv_buff = self._recv(_HEADER_SIZE)
             rv = self._admin_parse_header(recv_buff)
 
@@ -252,11 +252,9 @@ class Client(object):
     def _send_request(self, request, info_msg_version=2, info_msg_type=1):
         if request:
             request += '\n'
-        # struct.pack() used bytes in python 3
-        request_bytes = bytes(request, 'utf-8')
         proto = (info_msg_version << 56) | (info_msg_type << 48) | (len(request)+1)
         fmt_str = "! Q %ds B" % len(request)
-        buf = struct.pack(fmt_str, proto, request_bytes, 10)
+        buf = struct.pack(fmt_str, proto, request.encode(), 10)
 
         self._send(buf)
 
@@ -305,7 +303,7 @@ class Client(object):
                 # fatal when authentication is required.
                 raise e
 
-            return bcrypt.hashpw(password, "$2a$10$7EqJtq98hPqEX7fNZaFWoO")
+            return bcrypt.hashpw(password.encode(), b"$2a$10$7EqJtq98hPqEX7fNZaFWoO")
 
         return ""
 
@@ -325,7 +323,7 @@ class Client(object):
     def _buffer_to_string(self, buf):
         buf_str = ""
         for s in buf:
-            buf_str += s
+            buf_str += s.decode()
         return buf_str
 
     def _authenticate(self, user, password, password_field_id):

--- a/aerospike_discovery.py
+++ b/aerospike_discovery.py
@@ -399,9 +399,11 @@ class OutputStream():
         self.list.append("}")
         print("\n".join(self.list))
 
-###
-# Argument parsing
-###
+# =============================================================================
+#
+# Argument Parsing
+#
+# -----------------------------------------------------------------------------
 parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument('-u'
                     , '--usage'
@@ -543,9 +545,11 @@ if args.credentials:
     except IOError:
         print("Unable to read credentials file: %s"%args.credentials)
 
+# =============================================================================
 #
-# MAINLINE
+# Mainline
 #
+# -----------------------------------------------------------------------------
 
 try:
     client = Client(addr=args.host,port=args.port, timeout=args.timeout)

--- a/aerospike_discovery.py
+++ b/aerospike_discovery.py
@@ -666,6 +666,22 @@ res = res.strip()
 # Output stream collects output to send to stdout and looks up metrics
 stream = OutputStream()
 
+'''
+Note:  Responses are all single line.  Returns are added.
+
+latencies response example:
+"batch-index:;{test}-read:msec,10807.9,4.21,0.89,0.17,0.03,0.01,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00;
+{test}-write:msec,10872.4,4.98,1.06,0.18,0.04,0.01,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00;{test}-udf:;
+{test}-query:;{bar}-read:;{bar}-write:;{bar}-udf:;{bar}-query:"
+
+latency response example:
+"batch-index:;{test}-read:16:34:50-GMT,ops/sec,>1ms,>8ms,>64ms;16:35:00,0.0,0.00,0.00,0.00;
+{test}-write:16:34:50-GMT,ops/sec,>1ms,>8ms,>64ms;16:35:00,0.0,0.00,0.00,0.00;{test}-udf:;
+{test}-query:;{bar}-read:;{bar}-write:;{bar}-udf:;{bar}-query:"
+
+set response example, similar to namespace, bins, sindex:
+objects=100010:tombstones=0:memory_data_bytes=0:truncate_lut=0:stop-writes-count=0:disable-eviction=false;
+'''
 metric_found = False
 if args.latency:
     res = res.split(';')

--- a/aerospike_discovery.py
+++ b/aerospike_discovery.py
@@ -24,6 +24,7 @@ __author__ = "Aerospike"
 __copyright__ = "Copyright 2020 Aerospike"
 __version__ = "3.0.0"
 
+
 import sys
 import socket
 import re

--- a/aerospike_discovery.py
+++ b/aerospike_discovery.py
@@ -498,7 +498,7 @@ parser.add_argument("--tls-keyfile"
                     , help="The private keyfile for your client TLS Cert")
 parser.add_argument("--tls-keyfile-pw"
                     , dest="tls_keyfile_pw"
-                    , help="Password to load protected tls_keyfile")
+                    , help="Password to load protected tls-keyfile")
 parser.add_argument("--tls-certfile"
                     , dest="tls_certfile"
                     , help="The client TLS cert")
@@ -520,7 +520,7 @@ parser.add_argument("--tls-cert-blacklist"
 parser.add_argument("--tls-crl-check"
                     , dest="tls_crl_check"
                     , action="store_true"
-                    , help="Checks SSL/TLS certs against vendor's Certificate Revocation Lists for revoked certificates. CRLs are found in path specified by --tls_capath. Checks the leaf certificates only")
+                    , help="Checks SSL/TLS certs against vendor's Certificate Revocation Lists for revoked certificates. CRLs are found in path specified by --tls-capath. Checks the leaf certificates only")
 parser.add_argument("--tls-crl-check-all"
                     , dest="tls_crl_check_all"
                     , action="store_true"

--- a/aerospike_templates.xml
+++ b/aerospike_templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>5.0</version>
-    <date>2020-08-12T20:46:53Z</date>
+    <date>2020-08-29T00:32:56Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -53,28 +53,6 @@
                             <name>Aerospike_bins_{#METRICNAME}</name>
                             <type>CALCULATED</type>
                             <key>aerospike_bins_[{#METRICNAME}]</key>
-                            <delay>60</delay>
-                            <value_type>FLOAT</value_type>
-                            <units>{#METRICUNITS}</units>
-                            <params>{#METRICVALUE}</params>
-                            <applications>
-                                <application>
-                                    <name>Aerospike</name>
-                                </application>
-                            </applications>
-                        </item_prototype>
-                    </item_prototypes>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>Aerospike Latency {test}-write 8ms</name>
-                    <type>EXTERNAL</type>
-                    <key>aerospike_discovery.py[-h,{HOST.IP}, -l, -s, &quot;{test}-write-8ms&quot;]</key>
-                    <delay>60</delay>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Aerospike_latency_test_write_8ms</name>
-                            <type>CALCULATED</type>
-                            <key>asinfo_latency_test_[{#METRICNAME}]</key>
                             <delay>60</delay>
                             <value_type>FLOAT</value_type>
                             <units>{#METRICUNITS}</units>

--- a/aerospike_templates.xml
+++ b/aerospike_templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-    <version>4.4</version>
-    <date>2016-03-10T00:33:09Z</date>
+    <version>5.0</version>
+    <date>2020-08-12T20:46:53Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -11,7 +11,6 @@
         <template>
             <template>Template App Aerospike Service</template>
             <name>Template App Aerospike Service</name>
-            <description/>
             <groups>
                 <group>
                     <name>Templates</name>
@@ -26,396 +25,462 @@
                 <item>
                     <name>Aerospike</name>
                     <type>SIMPLE</type>
-                    <snmp_community/>
-                    <snmp_oid/>
                     <key>net.tcp.service[tcp,,3000]</key>
                     <delay>30</delay>
-                    <history>90d</history>
-                    <trends>365d</trends>
-                    <status>ENABLED</status>
-                    <value_type>UNSIGNED</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>NOAUTHNOPRIV</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>MD5</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>DES</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>NONE</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
                     <applications>
                         <application>
                             <name>Aerospike</name>
                         </application>
                     </applications>
-                    <logtimefmt/>
+                    <triggers>
+                        <trigger>
+                            <expression>{last(0)}=0</expression>
+                            <name>Aerospike service on {HOST.NAME}</name>
+                            <priority>AVERAGE</priority>
+                        </trigger>
+                    </triggers>
                 </item>
             </items>
             <discovery_rules>
                 <discovery_rule>
-                    <name>Aerospike Free</name>
+                    <name>Aerospike Bins</name>
                     <type>EXTERNAL</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>aerospike_discovery.py[-h,{HOST.IP}, -d,1]</key>
+                    <key>aerospike_discovery.py[-h,{HOST.IP}, -b, -n, test]</key>
                     <delay>60</delay>
-                    <status>ENABLED</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>NOAUTHNOPRIV</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>MD5</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>DES</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>NONE</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-					<port/>
-					<filter>
-						<conditions>
-							<condition>
-                                <macro>{#METRICNAME}</macro>
-                                <value>free-pct</value>
-                                <formulaid>A</formulaid>
-							</condition>
-						</conditions>
-					</filter>
-                    <lifetime>30d</lifetime>
-                    <description/>
+                    <description>Get all metrics for bins in namespace &quot;test&quot;.</description>
                     <item_prototypes>
                         <item_prototype>
-                            <name>Aerospike Free</name>
+                            <name>Aerospike_bins_{#METRICNAME}</name>
                             <type>CALCULATED</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>asfree_[{#METRICNAME}]</key>
+                            <key>aerospike_bins_[{#METRICNAME}]</key>
                             <delay>60</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>ENABLED</status>
-                            <value_type>UNSIGNED</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>NOAUTHNOPRIV</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>MD5</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>DES</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
                             <params>{#METRICVALUE}</params>
-                            <ipmi_sensor/>
-                            <authtype>NONE</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
                             <applications>
                                 <application>
                                     <name>Aerospike</name>
                                 </application>
                             </applications>
-                            <logtimefmt/>
                         </item_prototype>
                     </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template App Aerospike Service:asfree_[{#METRICNAME}].last()}&lt;{$ASD_FREE_PCT_LIMIT}</expression>
-                            <name>Aerospike Free Stats</name>
-                            <url/>
-                            <status>ENABLED</status>
-                            <description/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Aerospike Stats</name>
+                    <name>Aerospike Latency {test}-write 8ms</name>
                     <type>EXTERNAL</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>aerospike_discovery.py[-h,{HOST.IP}]</key>
+                    <key>aerospike_discovery.py[-h,{HOST.IP}, -l, -s, &quot;{test}-write-8ms&quot;]</key>
                     <delay>60</delay>
-                    <status>ENABLED</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>NOAUTHNOPRIV</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>MD5</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>DES</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>NONE</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-					<port/>
-                    <lifetime>0</lifetime>
-                    <description/>
                     <item_prototypes>
                         <item_prototype>
-                            <name>AEROSPIKE_STATS_{#METRICNAME}</name>
+                            <name>Aerospike_latency_test_write_8ms</name>
                             <type>CALCULATED</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>asinfo_stats[{#METRICNAME}]</key>
-                            <delay>30</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>ENABLED</status>
-                            <value_type>UNSIGNED</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>NOAUTHNOPRIV</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>MD5</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>DES</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
+                            <key>asinfo_latency_test_[{#METRICNAME}]</key>
+                            <delay>60</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
                             <params>{#METRICVALUE}</params>
-                            <ipmi_sensor/>
-                            <authtype>NONE</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
                             <applications>
                                 <application>
                                     <name>Aerospike</name>
                                 </application>
                             </applications>
-                            <logtimefmt/>
                         </item_prototype>
                     </item_prototypes>
-                    <trigger_prototypes/>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Aerospike Latency</name>
+                    <type>EXTERNAL</type>
+                    <key>aerospike_discovery.py[-h,{HOST.IP}, -l]</key>
+                    <delay>10</delay>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Aerospike_Latency_{#METRICNAME}</name>
+                            <type>CALCULATED</type>
+                            <key>asinfo_latency_[{#METRICNAME}]</key>
+                            <delay>60</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
+                            <params>{#METRICVALUE}</params>
+                            <applications>
+                                <application>
+                                    <name>Aerospike</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                    </item_prototypes>
                     <graph_prototypes>
                         <graph_prototype>
-                            <name>AS_GRAPH_{#METRICNAME}</name>
-                            <width>900</width>
-                            <height>200</height>
-                            <yaxismin>0.0000</yaxismin>
-                            <yaxismax>100.0000</yaxismax>
-                            <percent_left>0.0000</percent_left>
-                            <percent_right>0.0000</percent_right>
+                            <name>AS LATENCY GRAPH {#METRICNAME}</name>
                             <ymin_type_1>FIXED</ymin_type_1>
-                            <ymax_type_1>CALCULATED</ymax_type_1>
-                            <ymin_item_1>0</ymin_item_1>
-                            <ymax_item_1>0</ymax_item_1>
                             <graph_items>
                                 <graph_item>
-                                    <sortorder>0</sortorder>
                                     <color>00C800</color>
-                                    <type>SIMPLE</type>
                                     <item>
                                         <host>Template App Aerospike Service</host>
-                                        <key>asinfo_stats[{#METRICNAME}]</key>
+                                        <key>asinfo_latency_[{#METRICNAME}]</key>
                                     </item>
                                 </graph_item>
                             </graph_items>
                         </graph_prototype>
                     </graph_prototypes>
-                    <host_prototypes/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Aerospike Test Namespace Metric</name>
+                    <name>Aerospike Namespace Free</name>
                     <type>EXTERNAL</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>aerospike_discovery.py[-h,{HOST.IP},-n,test]</key>
+                    <key>aerospike_discovery.py[-h,{HOST.IP}, -n, test, -d,1]</key>
                     <delay>60</delay>
-                    <status>ENABLED</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>NOAUTHNOPRIV</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>MD5</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>DES</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>NONE</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <lifetime>0</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>ASINFO_NS_{#METRICNAME}</name>
-                            <type>CALCULATED</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>namespace_test[{#METRICNAME}]</key>
-                            <delay>60</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>ENABLED</status>
-                            <value_type>UNSIGNED</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>NOAUTHNOPRIV</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>MD5</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>DES</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params>{#METRICVALUE}</params>
-                            <ipmi_sensor/>
-                            <authtype>NONE</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <applications>
-                                <application>
-                                    <name>Aerospike</name>
-                                </application>
-                            </applications>
-                            <logtimefmt/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes/>
-                    <graph_prototypes>
-                        <graph_prototype>
-                            <name>AS NS Test GRAPH {#METRICNAME}</name>
-                            <width>900</width>
-                            <height>200</height>
-                            <yaxismin>0.0000</yaxismin>
-                            <yaxismax>100.0000</yaxismax>
-                            <percent_left>0.0000</percent_left>
-                            <percent_right>0.0000</percent_right>
-                            <ymin_type_1>FIXED</ymin_type_1>
-                            <ymax_type_1>CALCULATED</ymax_type_1>
-                            <ymin_item_1>0</ymin_item_1>
-                            <ymax_item_1>0</ymax_item_1>
-                            <graph_items>
-                                <graph_item>
-                                    <sortorder>0</sortorder>
-                                    <color>00C800</color>
-                                    <type>SIMPLE</type>
-                                    <item>
-                                        <host>Template App Aerospike Service</host>
-                                        <key>namespace_test[{#METRICNAME}]</key>
-                                    </item>
-                                </graph_item>
-                            </graph_items>
-                        </graph_prototype>
-                    </graph_prototypes>
-                    <host_prototypes/>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>Aerospike Writes Stopped</name>
-                    <type>EXTERNAL</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>aerospike_discovery.py[-h,{HOST.IP},-n,test,-d,1]</key>
-                    <delay>60</delay>
-                    <status>ENABLED</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>NOAUTHNOPRIV</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>MD5</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>DES</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>NONE</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-					<port/>
                     <filter>
                         <conditions>
                             <condition>
                                 <macro>{#METRICNAME}</macro>
-                                <value>stop-writes</value>
-                                <formulaid>B</formulaid>
+                                <value>free_pct</value>
+                                <formulaid>A</formulaid>
                             </condition>
                         </conditions>
-                    </filter>                    
-                    <lifetime>30d</lifetime>
-                    <description/>
+                    </filter>
                     <item_prototypes>
                         <item_prototype>
-                            <name>Aerospike Stop Writes</name>
-                            <type>EXTERNAL</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>as_stop_writes</key>
-                            <delay>30</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>ENABLED</status>
-                            <value_type>UNSIGNED</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>NOAUTHNOPRIV</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>MD5</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>DES</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>NONE</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
+                            <name>Aerospike_namespace_free_pct_{#METRICNAME}</name>
+                            <type>CALCULATED</type>
+                            <key>asinfo_namespace_free_pct_[{#METRICNAME}]</key>
+                            <delay>60</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
+                            <params>{#METRICVALUE}</params>
                             <applications>
                                 <application>
                                     <name>Aerospike</name>
                                 </application>
                             </applications>
-                            <logtimefmt/>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}&lt;{$ASD_FREE_PCT_LIMIT}</expression>
+                                    <name>Aerospike Free Stats</name>
+                                </trigger_prototype>
+                            </trigger_prototypes>
                         </item_prototype>
                     </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template App Aerospike Service:as_stop_writes.last()}=1</expression>
-                            <name>Aerospike Writes Stopped</name>
-                            <url/>
-                            <status>ENABLED</status>
-                            <description/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Aerospike Namespace Stop Writes</name>
+                    <type>EXTERNAL</type>
+                    <key>aerospike_discovery.py[-h,{HOST.IP},-n,test,-d,1]</key>
+                    <delay>60</delay>
+                    <filter>
+                        <conditions>
+                            <condition>
+                                <macro>{#METRICNAME}</macro>
+                                <value>stop_writes</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Aerospike_Stop_Writes_{#METRICNAME}</name>
+                            <type>CALCULATED</type>
+                            <key>asinfo_namespace_test_stop_writes_[{#METRICNAME}]</key>
+                            <delay>30</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
+                            <params>{#METRICVALUE}</params>
+                            <applications>
+                                <application>
+                                    <name>Aerospike</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}=1</expression>
+                                    <name>Aerospike Writes Stopped to Namespace Test</name>
+                                    <priority>HIGH</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Aerospike SIndex</name>
+                    <type>EXTERNAL</type>
+                    <key>aerospike_discovery.py[-h, {HOST.IP}, -n, test, -i, testsindex]</key>
+                    <delay>60</delay>
+                    <description>All metrics for the secondary index &quot;testsindex&quot; in the namespace &quot;test&quot; using asinfo -v &quot;sindex/test/testsindex&quot;.</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Aerospike_testsindex_sindex_{#METRICNAME}</name>
+                            <type>CALCULATED</type>
+                            <key>aerospike_testsindex_sindex_[{#METRICNAME}]</key>
+                            <delay>60</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
+                            <params>{#METRICVALUE}</params>
+                            <applications>
+                                <application>
+                                    <name>Aerospike</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Aerospike Set Tombstones</name>
+                    <type>EXTERNAL</type>
+                    <key>aerospike_discovery.py[-h,{HOST.IP}, -n, test, -t, testset, -d, 1]</key>
+                    <delay>60</delay>
+                    <filter>
+                        <conditions>
+                            <condition>
+                                <macro>{#METRICNAME}</macro>
+                                <value>tombstones</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Aerospike_set_tombstones</name>
+                            <type>CALCULATED</type>
+                            <key>asinfo_set_tombstones_[{#METRICNAME}]</key>
+                            <delay>60</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
+                            <params>{#METRICVALUE}</params>
+                            <applications>
+                                <application>
+                                    <name>Aerospike</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Aerospike Set</name>
+                    <type>EXTERNAL</type>
+                    <key>aerospike_discovery.py[-h, {HOST.IP}, -n, test, -t, testset]</key>
+                    <delay>60</delay>
+                    <description>Get all metrics for set &quot;testset&quot; in namespace &quot;test&quot; using asinfo -v &quot;sets/test/testset&quot;.</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Aerospike_testset_set_{#METRICNAME}</name>
+                            <type>CALCULATED</type>
+                            <key>aerospike_testset_set_[{#METRICNAME}]</key>
+                            <delay>60</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
+                            <params>{#METRICVALUE}</params>
+                            <applications>
+                                <application>
+                                    <name>Aerospike</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Aerospike Namespace</name>
+                    <type>EXTERNAL</type>
+                    <key>aerospike_discovery.py[-h,{HOST.IP},-n,test]</key>
+                    <delay>60</delay>
+                    <lifetime>0</lifetime>
+                    <description>Get all metrics for namespace test using asinfo -v &quot;namespace/test&quot;</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Aerospike_Namespace_Test_{#METRICNAME}</name>
+                            <type>CALCULATED</type>
+                            <key>asinfo_namespace_test_[{#METRICNAME}]</key>
+                            <delay>60</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
+                            <params>{#METRICVALUE}</params>
+                            <applications>
+                                <application>
+                                    <name>Aerospike</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                    </item_prototypes>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <name>AS NS Test GRAPH {#METRICNAME}</name>
+                            <ymin_type_1>FIXED</ymin_type_1>
+                            <graph_items>
+                                <graph_item>
+                                    <color>00C800</color>
+                                    <item>
+                                        <host>Template App Aerospike Service</host>
+                                        <key>asinfo_namespace_test_[{#METRICNAME}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Aerospike Stats Cluster Size</name>
+                    <type>EXTERNAL</type>
+                    <key>aerospike_discovery.py[-h,{HOST.IP}, -s, &quot;cluster_size&quot;]</key>
+                    <delay>60</delay>
+                    <description>Get the general statistic &quot;Cluster Size&quot;</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Aerospike_stats_cluster_size</name>
+                            <type>CALCULATED</type>
+                            <key>Aerospike_stats_[{#METRICNAME}]</key>
+                            <delay>60</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
+                            <params>{#METRICVALUE}</params>
+                            <applications>
+                                <application>
+                                    <name>Aerospike</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}=1</expression>
+                                    <name>Aerospike Cluster Size = 1</name>
+                                    <priority>WARNING</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Aerospike XDR Latency ms 5.0+</name>
+                    <type>EXTERNAL</type>
+                    <key>aerospike_discovery.py[-h,{HOST.IP}, -x, DC1, -d, 1, -d 1]</key>
+                    <delay>60</delay>
+                    <filter>
+                        <conditions>
+                            <condition>
+                                <macro>{#METRICNAME}</macro>
+                                <value>latency_ms</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Aerospike_xdr_latency_ms_{#METRICNAME}</name>
+                            <type>CALCULATED</type>
+                            <key>aerospike_xdr_latency_ms_[{#METRICNAME}]</key>
+                            <delay>60</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
+                            <params>{#METRICVALUE}</params>
+                            <applications>
+                                <application>
+                                    <name>Aerospike</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last(#3)}=100</expression>
+                                    <name>Aerospike XDR Latency High</name>
+                                    <priority>AVERAGE</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Aerospike XDR DC State pre 5.0</name>
+                    <type>EXTERNAL</type>
+                    <key>aerospike_discovery.py[-h,{HOST.IP}, -x, DC1, -d, 1]</key>
+                    <delay>60</delay>
+                    <filter>
+                        <conditions>
+                            <condition>
+                                <macro>{#METRICNAME}</macro>
+                                <value>dc_state</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Aerospike_xdr_dc_state_{#METRICNAME}</name>
+                            <type>CALCULATED</type>
+                            <key>aerospike_xdr_dc_state_[{#METRICNAME}]</key>
+                            <delay>60</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
+                            <params>{#METRICVALUE}</params>
+                            <applications>
+                                <application>
+                                    <name>Aerospike</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}=2</expression>
+                                    <name>Aerospike XDR Cluster Down</name>
+                                    <priority>HIGH</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Aerospike XDR</name>
+                    <type>EXTERNAL</type>
+                    <key>aerospike_discovery.py[-h,{HOST.IP}, -x, DC1]</key>
+                    <delay>60</delay>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Aerospike_xdr_{#METRICNAME}</name>
+                            <type>CALCULATED</type>
+                            <key>aerospike_xdr_[{#METRICNAME}]</key>
+                            <delay>60</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
+                            <params>{#METRICVALUE}</params>
+                            <applications>
+                                <application>
+                                    <name>Aerospike</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Aerospike Stats</name>
+                    <type>EXTERNAL</type>
+                    <key>aerospike_discovery.py[-h,{HOST.IP}]</key>
+                    <delay>60</delay>
+                    <lifetime>0</lifetime>
+                    <description>Get all metrics returned by asinfo -v &quot;statistics&quot;</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Aerospike_Stats_{#METRICNAME}</name>
+                            <type>CALCULATED</type>
+                            <key>asinfo_stats_[{#METRICNAME}]</key>
+                            <delay>30</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>{#METRICUNITS}</units>
+                            <params>{#METRICVALUE}</params>
+                            <applications>
+                                <application>
+                                    <name>Aerospike</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                    </item_prototypes>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <name>AS_GRAPH_{#METRICNAME}</name>
+                            <ymin_type_1>FIXED</ymin_type_1>
+                            <graph_items>
+                                <graph_item>
+                                    <color>00C800</color>
+                                    <item>
+                                        <host>Template App Aerospike Service</host>
+                                        <key>asinfo_stats_[{#METRICNAME}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
                 </discovery_rule>
             </discovery_rules>
             <macros>
@@ -424,19 +489,6 @@
                     <value>20</value>
                 </macro>
             </macros>
-            <templates/>
-            <screens/>
         </template>
     </templates>
-    <triggers>
-        <trigger>
-            <expression>{Template App Aerospike Service:net.tcp.service[tcp,,3000].last(0)}=0</expression>
-            <name>Aerospike service on {HOST.NAME}</name>
-            <url/>
-            <status>ENABLED</status>
-            <priority>AVERAGE</priority>
-            <description/>
-            <dependencies/>
-        </trigger>
-    </triggers>
 </zabbix_export>


### PR DESCRIPTION
JIRA task: https://aerospike.atlassian.net/browse/PROD-1215
Included feature request: https://aerospike.atlassian.net/browse/PROD-836

The is part of the larger effort to update aerospike monitoring tools to be up-to-date with version 4.0 and 5.0 of the aerospike server.

Changes made:
* ReadMe.md
  * Update known issues.
  * Update corresponding asinfo() commands.
  * Clarify how to create triggers from the default discovery rules provided.
  * Add examples for new metrics.
  * Add instructions for a credential file.
* aerospike_discivery.py
  * Create a helper class to store/format name/value pairs to send to stdout
  * Added support for metric contexts: XDR, latency(5.0)/latencies(5.1+), sets, bins, index
  * Add support for a credential file
* aerospike_templates.xml
  * Create an example discovery rule and item prototype for every new metric added.